### PR TITLE
Update dependencies, PHPUnit testsuite and config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: Continous Integration
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.4']
+        php-version: ['7.4', '8.0']
 
     steps:
       - uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
         "webmozart/assert": "^1.8"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^7.0.2",
+        "doctrine/coding-standard": "^8.0.2",
         "phpunit/phpunit": "^9.1",
         "roave/security-advisories": "dev-master",
-        "vimeo/psalm": "^3.11"
+        "vimeo/psalm": "^4.3"
     },
     "bin": [
         "bin/depreday"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,13 @@
 <?xml version="1.0"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-        beStrictAboutResourceUsageDuringSmallTests="true"
-        beStrictAboutChangesToGlobalState="true"
-        beStrictAboutOutputDuringTests="true"
-        bootstrap="./vendor/autoload.php"
-        verbose="true"
-        colors="true"
->
-    <testsuites>
-        <testsuite name="unit">
-            <directory>./tests/unit</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" beStrictAboutResourceUsageDuringSmallTests="true" beStrictAboutChangesToGlobalState="true" beStrictAboutOutputDuringTests="true" bootstrap="./vendor/autoload.php" verbose="true" colors="true">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Bin/ExtractDateTime.php
+++ b/src/Bin/ExtractDateTime.php
@@ -6,13 +6,14 @@ namespace Codelicia\Depreday\Bin;
 
 use DateTimeImmutable;
 use Webmozart\Assert\Assert;
+
 use function preg_match;
 
 final class ExtractDateTime
 {
     private const GIT_BLAME_DATE_TIME = '/.+\(.+(\d{4}-\d{2}-\d{2}) /';
 
-    public function __invoke(string $content) : DateTimeImmutable
+    public function __invoke(string $content): DateTimeImmutable
     {
         Assert::regex($content, self::GIT_BLAME_DATE_TIME);
 

--- a/src/Bin/Find.php
+++ b/src/Bin/Find.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Codelicia\Depreday\Bin;
 
 use Symfony\Component\Finder\Finder;
+
 use function array_map;
 use function basename;
 use function dirname;
@@ -25,13 +26,13 @@ final class Find
         $this->supportedExtensions = $supportedExtensions;
     }
 
-    private function getDirectory() : string
+    private function getDirectory(): string
     {
         return is_dir($this->directoryOrFile) ? $this->directoryOrFile : dirname($this->directoryOrFile);
     }
 
     /** @return string[] */
-    private function getFeatureMatch() : array
+    private function getFeatureMatch(): array
     {
         return is_dir($this->directoryOrFile)
             ? array_map(static fn ($x) => sprintf('*.%s', $x), $this->supportedExtensions)
@@ -39,7 +40,7 @@ final class Find
     }
 
     /** @psalm-param list<string> $excludeDirs */
-    public function __invoke(array $excludeDirs) : Finder
+    public function __invoke(array $excludeDirs): Finder
     {
         return Finder::create()
             ->files()

--- a/src/Bin/Grep.php
+++ b/src/Bin/Grep.php
@@ -9,11 +9,13 @@ use Codelicia\Depreday\FileLine;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Webmozart\Assert\Assert;
+
 use function array_filter;
 use function array_keys;
 use function array_map;
 use function explode;
 use function stripos;
+
 use const PHP_EOL;
 
 final class Grep
@@ -23,7 +25,7 @@ final class Grep
      *
      * @psalm-return ArrayObject
      */
-    public function __invoke(string $pattern, Finder $finder) : ArrayObject
+    public function __invoke(string $pattern, Finder $finder): ArrayObject
     {
         $collection = new ArrayObject();
 

--- a/src/Console/App.php
+++ b/src/Console/App.php
@@ -16,11 +16,12 @@ use DateTimeImmutable;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webmozart\Assert\Assert;
+
 use function array_map;
 
 final class App
 {
-    public function __invoke(InputInterface $input, OutputInterface $output) : int
+    public function __invoke(InputInterface $input, OutputInterface $output): int
     {
         $deprecationFound = false;
         $grep             = new Grep();

--- a/src/FileLine.php
+++ b/src/FileLine.php
@@ -17,17 +17,17 @@ final class FileLine
         $this->file = $file;
     }
 
-    public function line() : int
+    public function line(): int
     {
         return $this->line;
     }
 
-    public function getRelativePathname() : string
+    public function getRelativePathname(): string
     {
         return $this->file->getRelativePathname();
     }
 
-    public function getRealPath() : string
+    public function getRealPath(): string
     {
         return $this->file->getRealPath();
     }

--- a/src/Git/Blame.php
+++ b/src/Git/Blame.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Codelicia\Depreday\Git;
 
 use Symfony\Component\Process\Process;
+
 use function trim;
 
 final class Blame
 {
-    public function __invoke(string $fileRealPath, int $cursorPosition) : string
+    public function __invoke(string $fileRealPath, int $cursorPosition): string
     {
         $output = (new Process(['git', 'blame', '--date=short', '-L', $cursorPosition . ',+1', '--', $fileRealPath]))
             ->mustRun()

--- a/src/UI/Logo.php
+++ b/src/UI/Logo.php
@@ -18,7 +18,7 @@ final class Logo
     ];
 
     /** @return string[][] */
-    public static function logoMap() : array
+    public static function logoMap(): array
     {
         return self::LOGO;
     }

--- a/src/UI/Message.php
+++ b/src/UI/Message.php
@@ -7,6 +7,7 @@ namespace Codelicia\Depreday\UI;
 use DateInterval;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webmozart\Assert\Assert;
+
 use function count;
 use function random_int;
 use function sprintf;
@@ -19,7 +20,7 @@ final class Message
         'You have no deprecations, you are a legend!',
     ];
 
-    public function findingDeprecation(OutputInterface $output, string $directory) : void
+    public function findingDeprecation(OutputInterface $output, string $directory): void
     {
         $output->writeln("\nFinding deprecations in the directory: <info>" . $directory . "</info>\n\n");
     }
@@ -30,7 +31,7 @@ final class Message
         int $cursorPosition,
         string $phrase,
         DateInterval $dateInterval
-    ) : void {
+    ): void {
         if ($dateInterval->days === 0) {
             return;
         }
@@ -42,12 +43,12 @@ final class Message
         $output->writeln('');
     }
 
-    public function success(OutputInterface $output) : void
+    public function success(OutputInterface $output): void
     {
         $output->writeln(sprintf("%s\n\n", self::SUCCESS[random_int(0, count(self::SUCCESS) - 1)]));
     }
 
-    public function done(OutputInterface $output) : void
+    public function done(OutputInterface $output): void
     {
         $output->writeln('done.');
     }

--- a/src/UI/Phrases.php
+++ b/src/UI/Phrases.php
@@ -23,7 +23,7 @@ final class Phrases
         '%s days ago... a new deprecation comment was born 🙈',
     ];
 
-    public function random() : string
+    public function random(): string
     {
         return self::CONGRATULATION[random_int(0, count(self::CONGRATULATION) - 1)];
     }


### PR DESCRIPTION
# Changed log

- Adding `pull_request` trigger on GitHub Actions.
- Upgrading the `doctrine/coding-standard` to be the `^8.0.2` and it resolves following error:

```
composer install
No lock file found. Updating dependencies instead of installing from lock file. Use composer update over composer install if you do not have a lock file.
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - dealerdirect/phpcodesniffer-composer-installer v0.5.0 requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
    - doctrine/coding-standard 7.0.2 requires dealerdirect/phpcodesniffer-composer-installer ^0.5.0 -> satisfiable by dealerdirect/phpcodesniffer-composer-installer[v0.5.0].
    - Root composer.json requires doctrine/coding-standard ^7.0.2 -> satisfiable by doctrine/coding-standard[7.0.2].

You are using Composer 2, which some of your plugins seem to be incompatible with. Make sure you update your plugins or report a plugin-issue to ask them to support Composer 2.
```
- Using the `vendor/bin/phpunit --migrate-configuration` command to modify `phpunit.xml.dist` file.
- Fixing following coding style issues via `vendor/bin/phpcbf` command:

```


FILE: src/FileLine.php
--------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
--------------------------------------------------------------------------------
 20 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
 25 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
 30 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: src/Git/Blame.php
--------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------
  8 | ERROR | [x] Expected 1 lines between different types of use statement,
    |       |     found 0.
 12 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: src/UI/Phrases.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: src/Bin/ExtractDateTime.php
--------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------
  9 | ERROR | [x] Expected 1 lines between different types of use statement,
    |       |     found 0.
 15 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: src/UI/Logo.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 21 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: src/UI/Message.php
--------------------------------------------------------------------------------
FOUND 5 ERRORS AFFECTING 5 LINES
--------------------------------------------------------------------------------
 10 | ERROR | [x] Expected 1 lines between different types of use statement,
    |       |     found 0.
 22 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
 33 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
 45 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
 50 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 5 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: src/Console/App.php
--------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 19 | ERROR | [x] Expected 1 lines between different types of use statement,
    |       |     found 0.
 23 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: src/Bin/Find.php
--------------------------------------------------------------------------------
FOUND 4 ERRORS AFFECTING 4 LINES
--------------------------------------------------------------------------------
  8 | ERROR | [x] Expected 1 lines between different types of use statement,
    |       |     found 0.
 28 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
 34 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
 42 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 4 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: src/Bin/Grep.php
--------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
--------------------------------------------------------------------------------
 12 | ERROR | [x] Expected 1 lines between different types of use statement,
    |       |     found 0.
 17 | ERROR | [x] Expected 1 lines between different types of use statement,
    |       |     found 0.
 26 | ERROR | [x] There must be no whitespace between closing parenthesis and
    |       |     return type colon.
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------
```
- Adding `php-8.0` version test during GitHub Action building
- Upgrade `vimeo/psalm` to be `^4.3` for adding `php-8.0` version.