### PR TITLE
Adding string type hint to fix Psalm issues

### DIFF
--- a/src/Bin/Grep.php
+++ b/src/Bin/Grep.php
@@ -33,7 +33,7 @@ final class Grep
         foreach ($finder as $file) {
             $lines = explode(PHP_EOL, $file->getContents());
 
-            $cur = array_keys(array_filter(array_map(static fn ($line) => stripos($line, $pattern), $lines)));
+            $cur = array_keys(array_filter(array_map(static fn (string $line) => stripos($line, $pattern), $lines)));
 
             if ($cur === []) {
                 continue;


### PR DESCRIPTION
# Changed log

- Adding the `string` type hint to fix following Psalm issue message:

```
ERROR: MissingClosureParamType - src/Bin/Grep.php:36:65 - Parameter $line has no provided type (see https://psalm.dev/153)
            $cur = array_keys(array_filter(array_map(static fn ($line) => stripos($line, $pattern), $lines)));


ERROR: MixedArgument - src/Bin/Grep.php:36:83 - Argument 1 of stripos cannot be mixed, expecting string (see https://psalm.dev/030)
            $cur = array_keys(array_filter(array_map(static fn ($line) => stripos($line, $pattern), $lines)));
```